### PR TITLE
Add `bytes::padded_len_usize`

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -15,6 +15,18 @@ pub const fn padded_len(bytes: &[u8]) -> usize {
 pub const fn padded_len_usize(len: usize) -> usize {
     let pad = len % WORD_SIZE;
 
+    // `pad != 0` is checked because we shouldn't pad in case the length is already well-formed.
+    //
+    // Example being `w := WORD_SIZE` and `x := 2 · w`
+    //
+    // 1) With the check (correct result)
+    // f(x) -> x + (x % w != 0) · (w - x % w)
+    // f(x) -> x + 0 · w
+    // f(x) -> x
+    //
+    // 2) Without the check (incorrect result)
+    // f(x) -> x + w - x % w
+    // f(x) -> x + w
     len + (pad != 0) as usize * (WORD_SIZE - pad)
 }
 


### PR DESCRIPTION
In some cases, we might have to preemptively calculate the padded len of
a slice that is not yet created, so we can allocate the proper amount of
bytes and perform any relevant operation.

For that reason, the padded len must also be enabled for `usize`.