### PR TITLE
Bump to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-types"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "data-structures", "parsing"]
 edition = "2021"


### PR DESCRIPTION
Flagging as breaking due to the introduction of a new feature in https://github.com/FuelLabs/fuel-types/commit/389ad1bfd2d10bc82f53adfb0dbb0ce1fd71ebb5