### PR TITLE
Add `width` check to `fmt::{Lower,Upper}Hex`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ serde-big-array = { version = "0.3.2", default-features = false, optional = true
 
 [dev-dependencies]
 fuel-types = { path = ".", features = ["random"] }
+hex = "0.4"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-serde_json = "1.0.59"
+serde_json = "1.0"
 
 [features]
 default = ["std"]

--- a/src/types.rs
+++ b/src/types.rs
@@ -183,7 +183,13 @@ macro_rules! key_methods {
                     write!(f, "0x")?
                 }
 
-                self.0.iter().try_for_each(|b| write!(f, "{:02x}", &b))
+                match f.width() {
+                    Some(w) if w > 0 => self.0.chunks(Self::LEN / w).try_for_each(|c| {
+                        write!(f, "{:02x}", c.iter().fold(0u8, |acc, x| acc ^ x))
+                    }),
+
+                    _ => self.0.iter().try_for_each(|b| write!(f, "{:02x}", &b)),
+                }
             }
         }
 
@@ -193,19 +199,25 @@ macro_rules! key_methods {
                     write!(f, "0x")?
                 }
 
-                self.0.iter().try_for_each(|b| write!(f, "{:02X}", &b))
+                match f.width() {
+                    Some(w) if w > 0 => self.0.chunks(Self::LEN / w).try_for_each(|c| {
+                        write!(f, "{:02X}", c.iter().fold(0u8, |acc, x| acc ^ x))
+                    }),
+
+                    _ => self.0.iter().try_for_each(|b| write!(f, "{:02X}", &b)),
+                }
             }
         }
 
         impl fmt::Debug for $i {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "{:#x}", self)
+                <Self as fmt::LowerHex>::fmt(&self, f)
             }
         }
 
         impl fmt::Display for $i {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "{:#x}", self)
+                <Self as fmt::LowerHex>::fmt(&self, f)
             }
         }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -184,7 +184,7 @@ macro_rules! key_methods {
                 }
 
                 match f.width() {
-                    Some(w) if w > 0 => self.0.chunks(Self::LEN / w).try_for_each(|c| {
+                    Some(w) if w > 0 => self.0.chunks(2 * Self::LEN / w).try_for_each(|c| {
                         write!(f, "{:02x}", c.iter().fold(0u8, |acc, x| acc ^ x))
                     }),
 
@@ -200,7 +200,7 @@ macro_rules! key_methods {
                 }
 
                 match f.width() {
-                    Some(w) if w > 0 => self.0.chunks(Self::LEN / w).try_for_each(|c| {
+                    Some(w) if w > 0 => self.0.chunks(2 * Self::LEN / w).try_for_each(|c| {
                         write!(f, "{:02X}", c.iter().fold(0u8, |acc, x| acc ^ x))
                     }),
 

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -99,15 +99,9 @@ fn hex_encoding() {
         assert_eq!(t, upper);
         assert_eq!(t, upper_alternate);
 
-        let mut buf = [0u8; 2];
+        let reduced = t.as_ref().iter().fold(0u8, |acc, x| acc ^ x);
 
-        buf.iter_mut()
-            .zip(t.as_ref().chunks(t.as_ref().len() / 2))
-            .for_each(|(b, c)| {
-                *b = c.iter().fold(0u8, |acc, x| acc ^ x);
-            });
-
-        let x = hex::encode(buf);
+        let x = hex::encode(&[reduced]);
         let y = format!("{:2x}", t);
 
         assert_eq!(x, y);

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -63,13 +63,17 @@ fn from_slice_unchecked_safety() {
 fn hex_encoding() {
     fn encode_decode<T>(t: T)
     where
-        T: fmt::LowerHex + fmt::UpperHex + str::FromStr + Eq + fmt::Debug,
+        T: fmt::LowerHex + fmt::UpperHex + str::FromStr + Eq + fmt::Debug + AsRef<[u8]>,
         <T as str::FromStr>::Err: fmt::Debug,
     {
         let lower = format!("{:x}", t);
+        let lower_w0 = format!("{:0x}", t);
         let lower_alternate = format!("{:#x}", t);
+        let lower_alternate_w0 = format!("{:#0x}", t);
         let upper = format!("{:X}", t);
+        let upper_w0 = format!("{:0X}", t);
         let upper_alternate = format!("{:#X}", t);
+        let upper_alternate_w0 = format!("{:#X}", t);
 
         assert_ne!(lower, lower_alternate);
         assert_ne!(lower, upper);
@@ -77,6 +81,11 @@ fn hex_encoding() {
         assert_ne!(lower_alternate, upper);
         assert_ne!(lower_alternate, upper_alternate);
         assert_ne!(upper, upper_alternate);
+
+        assert_eq!(lower, lower_w0);
+        assert_eq!(lower_alternate, lower_alternate_w0);
+        assert_eq!(upper, upper_w0);
+        assert_eq!(upper_alternate, upper_alternate_w0);
 
         let lower = T::from_str(lower.as_str()).expect("Failed to parse lower");
         let lower_alternate =
@@ -89,18 +98,31 @@ fn hex_encoding() {
         assert_eq!(t, lower_alternate);
         assert_eq!(t, upper);
         assert_eq!(t, upper_alternate);
+
+        let mut buf = [0u8; 2];
+
+        buf.iter_mut()
+            .zip(t.as_ref().chunks(t.as_ref().len() / 2))
+            .for_each(|(b, c)| {
+                *b = c.iter().fold(0u8, |acc, x| acc ^ x);
+            });
+
+        let x = hex::encode(buf);
+        let y = format!("{:2x}", t);
+
+        assert_eq!(x, y);
     }
 
     let rng = &mut StdRng::seed_from_u64(8586);
 
-    encode_decode(rng.gen::<Address>());
-    encode_decode(rng.gen::<AssetId>());
-    encode_decode(rng.gen::<ContractId>());
-    encode_decode(rng.gen::<Bytes4>());
-    encode_decode(rng.gen::<Bytes8>());
-    encode_decode(rng.gen::<Bytes32>());
-    encode_decode(rng.gen::<Bytes64>());
-    encode_decode(rng.gen::<Salt>());
+    encode_decode::<Address>(rng.gen());
+    encode_decode::<AssetId>(rng.gen());
+    encode_decode::<ContractId>(rng.gen());
+    encode_decode::<Bytes4>(rng.gen());
+    encode_decode::<Bytes8>(rng.gen());
+    encode_decode::<Bytes32>(rng.gen());
+    encode_decode::<Bytes64>(rng.gen());
+    encode_decode::<Salt>(rng.gen());
 }
 
 #[test]

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -105,6 +105,14 @@ fn hex_encoding() {
         let y = format!("{:2x}", t);
 
         assert_eq!(x, y);
+
+        let x = format!("{:0x}", t).len();
+        let y = format!("{:2x}", t).len();
+        let z = format!("{:4x}", t).len();
+
+        assert_eq!(t.as_ref().len() * 2, x);
+        assert_eq!(2, y);
+        assert_eq!(4, z);
     }
 
     let rng = &mut StdRng::seed_from_u64(8586);


### PR DESCRIPTION
Its beneficial to have some truncation strategy for bytes representation
so they can be readable.

However, truncation alone may result in collisions and misleading
information.

This PR introduces the usage of `core::fmt::Formatter::width`, a Rust
standard for truncating formatted objects. It will reduce arbitrary
slices into smaller hex representations. These smaller representations
will be the result of the sum of XOR over the chunks of the original
bytes.

This is secure and will lead to unique representations, truncated only
to the available bits of the desired width.