### PR TITLE
Fix for serde-types-minimal feature is missing in Cargo.toml #32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,10 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 serde-big-array = { version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
-bincode = { version = "1.3.3"}
+bincode = "1.3"
 fuel-types = { path = ".", features = ["random"] }
 hex = "0.4"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
-serde_json = "1.0"
 
 [features]
 default = ["std", "serde?/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 serde-big-array = { version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
+bincode = { version = "1.3.3"}
 fuel-types = { path = ".", features = ["random"] }
 hex = "0.4"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ serde_json = "1.0"
 default = ["std", "serde?/default"]
 alloc = ["serde?/alloc"]
 random = ["rand"]
-serde = ["serde-big-array"]
+serde = ["dep:serde", "serde-big-array"]
 std = ["alloc", "serde?/std"]

--- a/README.md
+++ b/README.md
@@ -12,5 +12,4 @@ Rust implementation of the atomic types for the [FuelVM](https://github.com/Fuel
 - `std`: Unless set, the crate will link to the core-crate instead of the std-crate. More info [here](https://docs.rust-embedded.org/book/intro/no-std.html).
 - `alloc`: Use [Vec](https://doc.rust-lang.org/alloc/vec/struct.Vec.html) from [alloc](https://doc.rust-lang.org/alloc/index.html) for `no-std`.
 - `random`: Implement `no-std` [rand](https://crates.io/crates/rand) features for the provided types.
-- `serde-types`: Add support for [serde](https://crates.io/crates/serde) for the provided types.
-- `serde`: Add support for `no-std` [serde](https://crates.io/crates/serde) for the provided types.
+- `serde`: Add support for [serde](https://crates.io/crates/serde) for the provided types.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rust implementation of the atomic types for the [FuelVM](https://github.com/Fuel
 
 - `std`: Unless set, the crate will link to the core-crate instead of the std-crate. More info [here](https://docs.rust-embedded.org/book/intro/no-std.html).
 - `alloc`: Use [Vec](https://doc.rust-lang.org/alloc/vec/struct.Vec.html) from [alloc](https://doc.rust-lang.org/alloc/index.html) for `no-std`.
-- `alloc-serde`: Enable `alloc`, `serde/alloc` and `serde-types-minimal`.
+- `alloc-serde`: Enable `alloc`, `serde/alloc` and `serde`.
 - `random`: Implement `no-std` [rand](https://crates.io/crates/rand) features for the provided types.
 - `serde-types`: Add support for [serde](https://crates.io/crates/serde) for the provided types.
-- `serde-types-minimal`: Add support for `no-std` [serde](https://crates.io/crates/serde) for the provided types.
+- `serde`: Add support for `no-std` [serde](https://crates.io/crates/serde) for the provided types.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Rust implementation of the atomic types for the [FuelVM](https://github.com/Fuel
 
 - `std`: Unless set, the crate will link to the core-crate instead of the std-crate. More info [here](https://docs.rust-embedded.org/book/intro/no-std.html).
 - `alloc`: Use [Vec](https://doc.rust-lang.org/alloc/vec/struct.Vec.html) from [alloc](https://doc.rust-lang.org/alloc/index.html) for `no-std`.
-- `alloc-serde`: Enable `alloc`, `serde/alloc` and `serde`.
 - `random`: Implement `no-std` [rand](https://crates.io/crates/rand) features for the provided types.
 - `serde-types`: Add support for [serde](https://crates.io/crates/serde) for the provided types.
 - `serde`: Add support for `no-std` [serde](https://crates.io/crates/serde) for the provided types.

--- a/src/types.rs
+++ b/src/types.rs
@@ -25,10 +25,7 @@ const fn hex_val(c: u8) -> Option<u8> {
 macro_rules! key {
     ($i:ident, $s:expr) => {
         #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        #[cfg_attr(
-            feature = "serde-types-minimal",
-            derive(serde::Serialize, serde::Deserialize)
-        )]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         /// FuelVM atomic type.
         pub struct $i([u8; $s]);
 
@@ -45,23 +42,18 @@ macro_rules! key {
 
 macro_rules! key_with_big_array {
     ($i:ident, $s:expr) => {
-        #[cfg(feature = "serde-types-minimal")]
+        #[cfg(feature = "serde")]
         use serde_big_array::big_array;
-        #[cfg(feature = "serde-types-minimal")]
+        #[cfg(feature = "serde")]
         big_array! {
             BigArray;
             $s,
         }
 
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-        #[cfg_attr(
-            feature = "serde-types-minimal",
-            derive(serde::Serialize, serde::Deserialize)
-        )]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         /// FuelVM atomic type.
-        pub struct $i(
-            #[cfg_attr(feature = "serde-types-minimal", serde(with = "BigArray"))] [u8; $s],
-        );
+        pub struct $i(#[cfg_attr(feature = "serde", serde(with = "BigArray"))] [u8; $s]);
 
         key_methods!($i, $s);
 

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -129,17 +129,6 @@ fn hex_encoding() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn test_key_with_big_array_serde() {
-    let rng = &mut StdRng::seed_from_u64(8586);
-    let bytes64: Bytes64 = rng.gen();
-    let bytes64_t = bincode::serialize(&bytes64).expect("Failed to serialize Bytes64");
-    let bytes64_t: Bytes64 =
-        bincode::deserialize(&bytes64_t).expect("Failed to deserialize Bytes64");
-    assert_eq!(bytes64, bytes64_t);
-}
-
-#[test]
-#[cfg(feature = "serde")]
 fn test_key_serde() {
     let rng = &mut StdRng::seed_from_u64(8586);
     let adr: Address = rng.gen();
@@ -149,6 +138,7 @@ fn test_key_serde() {
     let bytes8: Bytes8 = rng.gen();
     let bytes32: Bytes32 = rng.gen();
     let salt: Salt = rng.gen();
+    let bytes64: Bytes64 = rng.gen();
 
     let adr_t = bincode::serialize(&adr).expect("Failed to serialize Address");
     let adr_t: Address = bincode::deserialize(&adr_t).expect("Failed to deserialize Address");
@@ -179,4 +169,9 @@ fn test_key_serde() {
     let salt_t = bincode::serialize(&salt).expect("Failed to serialize Salt");
     let salt_t: Salt = bincode::deserialize(&salt_t).expect("Failed to deserialize Salt");
     assert_eq!(salt, salt_t);
+
+    let bytes64_t = bincode::serialize(&bytes64).expect("Failed to serialize Bytes64");
+    let bytes64_t: Bytes64 =
+        bincode::deserialize(&bytes64_t).expect("Failed to deserialize Bytes64");
+    assert_eq!(bytes64, bytes64_t);
 }

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -129,10 +129,54 @@ fn hex_encoding() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn test_key_with_big_array() {
+fn test_key_with_big_array_serde() {
     let rng = &mut StdRng::seed_from_u64(8586);
-    let s: Bytes64 = rng.gen();
-    let j = serde_json::to_string(&s).unwrap();
-    let s_back = serde_json::from_str(&j).unwrap();
-    assert!(s == s_back);
+    let bytes64: Bytes64 = rng.gen();
+    let bytes64_t = bincode::serialize(&bytes64).expect("Failed to serialize Bytes64");
+    let bytes64_t: Bytes64 =
+        bincode::deserialize(&bytes64_t).expect("Failed to deserialize Bytes64");
+    assert_eq!(bytes64, bytes64_t);
+}
+
+#[test]
+#[cfg(feature = "serde")]
+fn test_key_serde() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+    let adr: Address = rng.gen();
+    let ast_id: AssetId = rng.gen();
+    let contract_id: ContractId = rng.gen();
+    let bytes4: Bytes4 = rng.gen();
+    let bytes8: Bytes8 = rng.gen();
+    let bytes32: Bytes32 = rng.gen();
+    let salt: Salt = rng.gen();
+
+    let adr_t = bincode::serialize(&adr).expect("Failed to serialize Address");
+    let adr_t: Address = bincode::deserialize(&adr_t).expect("Failed to deserialize Address");
+    assert_eq!(adr, adr_t);
+
+    let ast_id_t = bincode::serialize(&ast_id).expect("Failed to serialize AssetId");
+    let ast_id_t: AssetId = bincode::deserialize(&ast_id_t).expect("Failed to deserialize AssetId");
+    assert_eq!(ast_id, ast_id_t);
+
+    let contract_id_t = bincode::serialize(&contract_id).expect("Failed to serialize ContractId");
+    let contract_id_t: ContractId =
+        bincode::deserialize(&contract_id_t).expect("Failed to deserialize ContractId");
+    assert_eq!(contract_id, contract_id_t);
+
+    let bytes4_t = bincode::serialize(&bytes4).expect("Failed to serialize Bytes4");
+    let bytes4_t: Bytes4 = bincode::deserialize(&bytes4_t).expect("Failed to deserialize Bytes4");
+    assert_eq!(bytes4, bytes4_t);
+
+    let bytes8_t = bincode::serialize(&bytes8).expect("Failed to serialize Bytes8");
+    let bytes8_t: Bytes8 = bincode::deserialize(&bytes8_t).expect("Failed to deserialize Bytes8");
+    assert_eq!(bytes8, bytes8_t);
+
+    let bytes32_t = bincode::serialize(&bytes32).expect("Failed to serialize Bytes32");
+    let bytes32_t: Bytes32 =
+        bincode::deserialize(&bytes32_t).expect("Failed to deserialize Bytes32");
+    assert_eq!(bytes32, bytes32_t);
+
+    let salt_t = bincode::serialize(&salt).expect("Failed to serialize Salt");
+    let salt_t: Salt = bincode::deserialize(&salt_t).expect("Failed to deserialize Salt");
+    assert_eq!(salt, salt_t);
 }

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -128,7 +128,7 @@ fn hex_encoding() {
 }
 
 #[test]
-#[cfg(feature = "serde-types-minimal")]
+#[cfg(feature = "serde")]
 fn test_key_with_big_array() {
     let rng = &mut StdRng::seed_from_u64(8586);
     let s: Bytes64 = rng.gen();


### PR DESCRIPTION
I changed  `#[cfg(feature = "serde-types-minimal")]` to  `#[cfg(feature = "serde")]` so that CI will run `test_key_with_big_array` test. 

### To test

- Tried CI steps locally
- `cargo test --all-targets --features serde` should run `test_key_with_big_array` test