### PR TITLE
For: Use hex-serialization for byte-array based types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ description = "Atomic types of the FuelVM."
 [dependencies]
 rand = { version = "0.8", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
-serde-big-array = { version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 fuel-types = { path = ".", features = ["random"] }
@@ -25,5 +24,5 @@ serde_json = "1.0"
 default = ["std", "serde?/default"]
 alloc = ["serde?/alloc"]
 random = ["rand"]
-serde = ["serde-big-array"]
+serde-types-minimal = ["serde"]
 std = ["alloc", "serde?/std"]

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -136,3 +136,13 @@ fn test_key_with_big_array() {
     let s_back = serde_json::from_str(&j).unwrap();
     assert!(s == s_back);
 }
+
+#[test]
+#[cfg(feature = "serde-types-minimal")]
+fn test_key() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+    let s: Bytes32 = rng.gen();
+    let j = serde_json::to_string(&s).unwrap();
+    let s_back = serde_json::from_str(&j).unwrap();
+    assert!(s == s_back);
+}


### PR DESCRIPTION
byte-array based types are serialized and deserialized as hex by `serde`. `Serialize` and `Deserialize` are implemented for both `key!` and `key_with_big_array!` types. 

Since we use custom serialization for both `key!` and `key_with_big_array!` we might want to drop `key_with_big_array!` and make `Bytes64` a `key!` type as well. This would also mean we can drop `serde-big-array` dependency since `serde-big-array` won't be used to serialize/deserialize the `Bytes64`.

### To Test

- `test_key_types_hex_serialization` test needs to be passing