### PR TITLE
Improve safety docs

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -59,9 +59,9 @@ where
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of `buf` is smaller than a word.
 pub unsafe fn restore_number_unchecked<T>(buf: &[u8]) -> (T, &[u8])
 where
     T: From<Word>,
@@ -76,9 +76,9 @@ where
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of `buf` is smaller than a word.
 pub unsafe fn restore_word_unchecked(buf: &[u8]) -> (Word, &[u8]) {
     let number = from_slice_unchecked(buf);
     let number = Word::from_be_bytes(number);
@@ -90,9 +90,9 @@ pub unsafe fn restore_word_unchecked(buf: &[u8]) -> (Word, &[u8]) {
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of `buf` is smaller than a word.
 pub unsafe fn restore_u8_unchecked(buf: &[u8]) -> (u8, &[u8]) {
     let number = from_slice_unchecked(buf);
     let number = Word::from_be_bytes(number) as u8;
@@ -104,9 +104,9 @@ pub unsafe fn restore_u8_unchecked(buf: &[u8]) -> (u8, &[u8]) {
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of `buf` is smaller than a word.
 pub unsafe fn restore_u16_unchecked(buf: &[u8]) -> (u16, &[u8]) {
     let number = from_slice_unchecked(buf);
     let number = Word::from_be_bytes(number) as u16;
@@ -118,9 +118,9 @@ pub unsafe fn restore_u16_unchecked(buf: &[u8]) -> (u16, &[u8]) {
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of the buffer is smaller than a word.
 pub unsafe fn restore_u32_unchecked(buf: &[u8]) -> (u32, &[u8]) {
     let number = from_slice_unchecked(buf);
     let number = Word::from_be_bytes(number) as u32;
@@ -132,9 +132,9 @@ pub unsafe fn restore_u32_unchecked(buf: &[u8]) -> (u32, &[u8]) {
 ///
 /// Return the read word and the remainder of the buffer
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of the buffer is smaller than a word
+/// Will cause undefined behaviour if the length of `buf` is smaller than a word.
 pub unsafe fn restore_usize_unchecked(buf: &[u8]) -> (usize, &[u8]) {
     let number = from_slice_unchecked(buf);
     let number = Word::from_be_bytes(number) as usize;
@@ -160,19 +160,18 @@ pub fn store_array_unchecked<'a, const N: usize>(
 ///
 /// Return the read array and the remainder bytes.
 ///
-/// # Panics
+/// # Safety
 ///
-/// This function will panic if the length of `buf` is smaller than `N`
+/// Will cause undefined behaviour if the length of `buf` is smaller than `N`.
 pub unsafe fn restore_array_unchecked<const N: usize>(buf: &[u8]) -> ([u8; N], &[u8]) {
     (from_slice_unchecked(buf), &buf[N..])
 }
 
 /// Add a conversion from arbitrary slices into arrays
 ///
-/// # Warning
+/// # Safety
 ///
-/// This function will not panic if the length of the slice is smaller than `N`. Instead, it will
-/// cause undefined behavior and read random disowned bytes.
+/// Will cause undefined behavior if the length of the slice is smaller than `N`.
 pub unsafe fn from_slice_unchecked<const N: usize>(buf: &[u8]) -> [u8; N] {
     let ptr = buf.as_ptr() as *const [u8; N];
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,16 +102,19 @@ macro_rules! key_methods {
 
             /// Add a conversion from arbitrary slices into owned
             ///
-            /// # Warning
+            /// # Safety
             ///
-            /// This function will not panic if the length of the slice is smaller than
-            /// `Self::LEN`. Instead, it will cause undefined behavior and read random disowned
-            /// bytes
+            /// This will cause undefined behavior if the length of the slice is smaller than
+            /// `Self::LEN`.
             pub unsafe fn from_slice_unchecked(bytes: &[u8]) -> Self {
                 $i(bytes::from_slice_unchecked(bytes))
             }
 
             /// Copy-free reference cast
+            ///
+            /// # Safety
+            ///
+            /// Given bytes must be a valid value of this type
             pub unsafe fn as_ref_unchecked(bytes: &[u8]) -> &Self {
                 // The interpreter will frequently make references to keys and values using
                 // logically checked slices.


### PR DESCRIPTION
Adds `Safety` section to docs of all `unsafe` functions. When function had `Panics` section but could cause UB before panic, the docs has been renamed to `Safety`. Also reworded some sections to explicitly mention undefined behaviour.