### PR TITLE
Deny clippy warnings and dbg_macro lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           - command: fmt
             args: --all --verbose -- --check
           - command: clippy
-            args: --all-targets --all-features
+            args: --all-targets --all-features -- -D warnings -D clippy::dbg_macro
           - command: check
             args: --all-targets --all-features
           - command: check


### PR DESCRIPTION
Related: https://github.com/FuelLabs/fuel-vm/issues/163