### PR TITLE
Version Bump to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-types"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "data-structures", "parsing"]
 edition = "2021"


### PR DESCRIPTION
This version Bump is needed to update `fuel-core-interfaces` so that `Bytes20` can be accessible which is in turn needed to fix #469 