### PR TITLE
Added const `len` function to get the size of the key

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -104,6 +104,11 @@ macro_rules! key_methods {
                 // access
                 &*(bytes.as_ptr() as *const Self)
             }
+
+            /// The memory length of the type by the method.
+            pub const fn len(&self) -> usize {
+                Self::LEN
+            }
         }
 
         #[cfg(feature = "random")]

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -36,6 +36,11 @@ macro_rules! check_consistency {
             assert_eq!(a, c);
             assert_eq!(a, d);
             assert_eq!(&a, e);
+            assert_eq!(a.len(), $i::LEN);
+            assert_eq!(b.len(), $i::LEN);
+            assert_eq!(c.len(), $i::LEN);
+            assert_eq!(d.len(), $i::LEN);
+            assert_eq!(e.len(), $i::LEN);
         }
     };
 }


### PR DESCRIPTION
It is helpful in the macros where we have variables but don't want to specify the type in the macro signature.