### PR TITLE
Move `UtxoId` from `fuel-tx` to `fuel-types`

### DIFF
--- a/tests/types.rs
+++ b/tests/types.rs
@@ -205,8 +205,7 @@ fn test_key_serde() {
     assert_eq!(bytes64, bytes64_t);
 
     let uxto_id_t = bincode::serialize(&uxto_id).expect("Failed to serialize UtxoId");
-    let uxto_id_t: UtxoId =
-        bincode::deserialize(&uxto_id_t).expect("Failed to deserialize UtxoId");
+    let uxto_id_t: UtxoId = bincode::deserialize(&uxto_id_t).expect("Failed to deserialize UtxoId");
     assert_eq!(uxto_id, uxto_id_t);
 }
 


### PR DESCRIPTION
In the `fuel-core` we have custom `AsRef<[u8]>` for `UtxoId`. We represent `UtxoId` as 33 bytes and use it as a key for data.

`fuel-tx` serialize it as 40 bytes where 32 bytes it `TxId` and 8 bytes are `output_index: u8`. It is because each separate field in the struct should be `WORD_SIZE` during serialization in the `fuel-tx`.

We can represent `UtxoId` as 33 bytes and know that the last byte is an `output_index`. We don't need to make it a separate field. `UtxoId` can provide two getter methods for `tx_id` and `output_index`.

It is breaking change but:
- It reduces the size of all transactions (instead of 40 bytes, we need 33 bytes).
- Makes `UtxoId` the same as other ids(`ContractId`, `MessageId`).
- We have one serialization model in `fuel-tx` and `fuel-core`.